### PR TITLE
_ledCount & spi device name improvements

### DIFF
--- a/lib/lpd8806-asyncfx.js
+++ b/lib/lpd8806-asyncfx.js
@@ -3,7 +3,7 @@ var Color = require('color');
 var LPD8806 = require('lpd8806-async');
 var async = require('async');
 
-module.exports = function(_ledCount) {
+module.exports = function(_ledCount, _device) {
     'use strict';
     var ledCount;
     if (typeof _ledCount !== 'number') {
@@ -11,8 +11,11 @@ module.exports = function(_ledCount) {
     } else {
         ledCount = parseInt(_ledCount, 10);
     }
+
+    var device = _device || '/dev/spidev1.0';
+
     // Internal reference to lpd8806-async
-    var leds = new LPD8806(ledCount, '/dev/spidev1.0');
+    var leds = new LPD8806(ledCount, device);
     leds.fillRGB(0, 0, 0); // Initialize off
 
     // Private utility functions & variables

--- a/lib/lpd8806-asyncfx.js
+++ b/lib/lpd8806-asyncfx.js
@@ -9,7 +9,7 @@ module.exports = function(_ledCount) {
     if (typeof _ledCount !== 'number') {
         throw 'Invalid number of led\'s.';
     } else {
-        ledCount = parseInt(_ledCount, 32);
+        ledCount = parseInt(_ledCount, 10);
     }
     // Internal reference to lpd8806-async
     var leds = new LPD8806(ledCount, '/dev/spidev1.0');


### PR DESCRIPTION
I've been extending your lpd8806-asyncfx module into a REST API and identified these 2 improvements that I thought might be helpful to others.  

The parseInt fix perplexed me for a while because I had to set the _ledCount to 50 for my LED light strip which has 160 LEDs.  It wasn't until I looked up the documentation for parseInt() that I realized it's second argument is the radix or base of the number.

The (optional) parameterization of the spi device name was required for me because my raspi has /dev/spidev0.0 and /dev/spidev0.1 but your code uses /dev/spidev1.0 (which I left as the default).